### PR TITLE
Updates spec_helper so that capybara tests will run

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 ENV["SINATRA_ENV"] = "test"
 require_relative '../config/environment.rb'
 require 'rack/test'
+require 'capybara/rspec'
+require 'capybara/dsl'
 
 RSpec.configure do |config|
   config.include Capybara::DSL


### PR DESCRIPTION
Capybara was being called within the RSpec.configure block without being first required and this was throwing an error. Adding the requirements above at the top of the spec_helper resolves the issue.